### PR TITLE
Adding Blood Glucose functionality

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,21 +7,32 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
+    activesupport (5.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     climate_control (0.2.0)
     coderay (1.1.3)
+    concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
     hashdiff (1.0.1)
     httparty (0.18.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
+    minitest (5.11.3)
     multi_xml (0.6.0)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -41,6 +52,9 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
     safe_yaml (1.0.5)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -53,6 +67,7 @@ DEPENDENCIES
   bundler
   climate_control
   dexcom!
+  factory_bot
   pry
   rspec
   webmock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dexcom (0.1.0)
+    dexcom (0.2.0)
       httparty
 
 GEM

--- a/dexcom.gemspec
+++ b/dexcom.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'climate_control'
+  spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'webmock'

--- a/lib/dexcom.rb
+++ b/lib/dexcom.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'dexcom/authentication'
+require 'dexcom/blood_glucose'
 require 'dexcom/configuration'
 require 'dexcom/constants'
 require 'dexcom/version'

--- a/lib/dexcom/blood_glucose.rb
+++ b/lib/dexcom/blood_glucose.rb
@@ -7,5 +7,42 @@ module Dexcom
   class BloodGlucose
     extend BloodGlucoseUtils::ApiHandler
     extend BloodGlucoseUtils::ClassMethods
+
+    MGDL_TO_MMOL_FACTOR = 0.0555
+
+    TRENDS = {
+      0 => { symbol: '', description: '' },
+      1 => { symbol: '↑↑', description: 'Rising quickly' },
+      2 => { symbol: '↑', description: 'Rising' },
+      3 => { symbol: '↗', description: 'Rising slightly' },
+      4 => { symbol: '→', description: 'Steady' },
+      5 => { symbol: '↘', description: 'Falling slightly' },
+      6 => { symbol: '↓', description: 'Falling' },
+      7 => { symbol: '↓↓', description: 'Falling quickly' },
+      8 => { symbol: '?', description: 'Undetermined' },
+      9 => { symbol: '-', description: 'Trend unavailable' }
+    }.freeze
+
+    attr_reader :timestamp, :trend, :value
+
+    alias mg_dl value
+
+    def initialize(value, trend, timestamp)
+      @value = value
+      @trend = trend
+      @timestamp = timestamp
+    end
+
+    def mmol
+      (mg_dl * MGDL_TO_MMOL_FACTOR).round(1)
+    end
+
+    def trend_symbol
+      TRENDS.dig(trend, :symbol)
+    end
+
+    def trend_description
+      TRENDS.dig(trend, :description)
+    end
   end
 end

--- a/lib/dexcom/blood_glucose.rb
+++ b/lib/dexcom/blood_glucose.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Dexcom
+  class BloodGlucose
+    DEFAULT_NUMBER_OF_VALUES = 1
+    MAX_MINUTES = 1440
+    MINUTES_PER_DATAPOINT = 5
+
+    class << self
+      def last
+        get_last(max_count: 1)
+      end
+
+      def get_last(max_count: nil, minutes: nil)
+        number_of_values =
+          if minutes.nil?
+            max_count || DEFAULT_NUMBER_OF_VALUES
+          elsif max_count.nil?
+            minutes / MINUTES_PER_DATAPOINT
+          else
+            [max_count, minutes / MINUTES_PER_DATAPOINT].min
+          end
+
+        response = HTTParty.post(
+          endpoint,
+          headers: headers,
+          query: query(number_of_values)
+        ).to_json
+      end
+
+      private
+
+      def endpoint
+        "#{config.base_url}/Publisher/ReadPublisherLatestGlucoseValues"
+      end
+
+      def headers
+        {
+          'User-Agent' => USER_AGENT
+        }
+      end
+
+      def query(max_count)
+        {
+          maxCount: max_count,
+          minutes: MAX_MINUTES
+        }
+      end
+
+      def config
+        @config ||= Dexcom.configuration
+      end
+    end
+  end
+end

--- a/lib/dexcom/blood_glucose.rb
+++ b/lib/dexcom/blood_glucose.rb
@@ -1,55 +1,11 @@
 # frozen_string_literal: true
 
+require 'dexcom/blood_glucose/api_handler'
+require 'dexcom/blood_glucose/class_methods'
+
 module Dexcom
   class BloodGlucose
-    DEFAULT_NUMBER_OF_VALUES = 1
-    MAX_MINUTES = 1440
-    MINUTES_PER_DATAPOINT = 5
-
-    class << self
-      def last
-        get_last(max_count: 1)
-      end
-
-      def get_last(max_count: nil, minutes: nil)
-        number_of_values =
-          if minutes.nil?
-            max_count || DEFAULT_NUMBER_OF_VALUES
-          elsif max_count.nil?
-            minutes / MINUTES_PER_DATAPOINT
-          else
-            [max_count, minutes / MINUTES_PER_DATAPOINT].min
-          end
-
-        response = HTTParty.post(
-          endpoint,
-          headers: headers,
-          query: query(number_of_values)
-        ).to_json
-      end
-
-      private
-
-      def endpoint
-        "#{config.base_url}/Publisher/ReadPublisherLatestGlucoseValues"
-      end
-
-      def headers
-        {
-          'User-Agent' => USER_AGENT
-        }
-      end
-
-      def query(max_count)
-        {
-          maxCount: max_count,
-          minutes: MAX_MINUTES
-        }
-      end
-
-      def config
-        @config ||= Dexcom.configuration
-      end
-    end
+    extend BloodGlucoseUtils::ApiHandler
+    extend BloodGlucoseUtils::ClassMethods
   end
 end

--- a/lib/dexcom/blood_glucose/api_handler.rb
+++ b/lib/dexcom/blood_glucose/api_handler.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Dexcom
+  module BloodGlucoseUtils
+    module ApiHandler
+      MAX_MINUTES = 1440
+
+      def make_api_request(number_of_values)
+        HTTParty.post(
+          endpoint,
+          headers: headers,
+          query: query(number_of_values)
+        )
+      end
+
+      def process_api_response(response)
+        response_body = JSON.parse(response.body)
+
+        response_body.map { |blood_glucose_item| build_from_api_response(blood_glucose_item) }
+      end
+
+      def build_from_api_response(blood_glucose_response_item)
+        Dexcom::BloodGlucose.new(
+          blood_glucose_response_item['Value'],
+          blood_glucose_response_item['Trend'],
+          parse_timestamp(blood_glucose_response_item)
+        )
+      end
+
+      private
+
+      def endpoint
+        "#{config.base_url}/Publisher/ReadPublisherLatestGlucoseValues"
+      end
+
+      def headers
+        {
+          'User-Agent' => USER_AGENT
+        }
+      end
+
+      def query(max_count)
+        {
+          maxCount: max_count,
+          minutes: MAX_MINUTES
+        }
+      end
+
+      def parse_timestamp(blood_glucose_response_item)
+        timestamp_info = blood_glucose_response_item['WT']
+        timestamp_regex = /(\d+)000/
+        timestamp = timestamp_info[timestamp_regex, 1]
+        utc = '+00:00'
+
+        DateTime.parse(Time.at(timestamp.to_i, in: utc).to_s)
+      end
+
+      def config
+        @config ||= Dexcom.configuration
+      end
+    end
+  end
+end

--- a/lib/dexcom/blood_glucose/class_methods.rb
+++ b/lib/dexcom/blood_glucose/class_methods.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal
+
+module Dexcom
+  module BloodGlucoseUtils
+    module ClassMethods
+      DEFAULT_NUMBER_OF_VALUES = 1
+      MINUTES_PER_DATAPOINT = 5
+
+      def last
+        get_last(max_count: 1)
+      end
+
+      def get_last(max_count: nil, minutes: nil)
+        number_of_values = calculate_number_of_values(max_count, minutes)
+
+        response = make_api_request(number_of_values)
+        process_api_response(response)
+      end
+
+      private
+
+      def calculate_number_of_values(max_count, minutes)
+        if minutes.nil?
+          max_count || DEFAULT_NUMBER_OF_VALUES
+        elsif max_count.nil?
+          minutes / MINUTES_PER_DATAPOINT
+        else
+          [max_count, minutes / MINUTES_PER_DATAPOINT].min
+        end
+      end
+    end
+  end
+end

--- a/lib/dexcom/version.rb
+++ b/lib/dexcom/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dexcom
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/dexcom/blood_glucose_spec.rb
+++ b/spec/dexcom/blood_glucose_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'retrieves blood glucose values' do |number_of_values|
+  let(:base_url) { 'https://shareous1.dexcom.com/ShareWebServices/Services' }
+  let(:blood_glucose_response_item) do
+    [{
+      'DT': '/Date(1591500198000+0000)/',
+      'ST': '/Date(1591492998000)/',
+      'Trend': 4,
+      'Value': 96,
+      'WT': '/Date(1591492998000)/'
+    }]
+  end
+  let(:expected_response_body) { (blood_glucose_response_item * number_of_values).to_json }
+
+  before do
+    @blood_glucose_request =
+      stub_request(:post, "#{base_url}/Publisher/ReadPublisherLatestGlucoseValues")
+      .with(
+        headers: { 'User-Agent' => 'Dexcom Share/3.0.2.11 CFNetwork/711.2.23 Darwin/14.0.0' },
+        query: { minutes: 1440, maxCount: number_of_values }
+      )
+      .to_return(status: 200, body: expected_response_body)
+  end
+
+  it 'makes a request to the API' do
+    subject
+
+    expect(@blood_glucose_request).to have_been_made.times(1)
+  end
+end
+
+RSpec.describe Dexcom::BloodGlucose do
+  describe '.get_last' do
+    context 'when is called without arguments' do
+      subject { Dexcom::BloodGlucose.get_last }
+
+      it_behaves_like 'retrieves blood glucose values', 1
+    end
+
+    context 'when is called with max_count' do
+      max_count = 5
+      subject { Dexcom::BloodGlucose.get_last(max_count: max_count) }
+
+      it_behaves_like 'retrieves blood glucose values', max_count
+    end
+
+    context 'when is called with minutes' do
+      minutes = 15
+      subject { Dexcom::BloodGlucose.get_last(minutes: minutes) }
+
+      it_behaves_like 'retrieves blood glucose values', (minutes / 5)
+    end
+
+    context 'when is called with a max_count and minutes' do
+      minutes = 20
+      max_count = 6
+      subject { Dexcom::BloodGlucose.get_last(minutes: minutes, max_count: max_count) }
+
+      it_behaves_like 'retrieves blood glucose values', [minutes / 5, max_count].min
+    end
+  end
+
+  describe '.last' do
+    subject { Dexcom::BloodGlucose.last }
+
+    it_behaves_like 'retrieves blood glucose values', 1
+  end
+end

--- a/spec/dexcom/blood_glucose_spec.rb
+++ b/spec/dexcom/blood_glucose_spec.rb
@@ -65,5 +65,5 @@ RSpec.describe Dexcom::BloodGlucose do
     subject { Dexcom::BloodGlucose.last }
 
     it_behaves_like 'retrieves blood glucose values', 1
-  end
+  end 
 end

--- a/spec/factories/blood_glucoses.rb
+++ b/spec/factories/blood_glucoses.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :blood_glucose, class: 'Dexcom::BloodGlucose' do
+    value { 142 }
+    trend { 3 }
+    timestamp { DateTime.new(2020, 6, 10, 21, 43, 14, '+00:00') }
+
+    initialize_with { new(value, trend, timestamp) }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,4 +23,10 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  # FactoryBot configuration
+  config.include FactoryBot::Syntax::Methods
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
 end


### PR DESCRIPTION
## Description
Implementing logic to retrieve live Blood Glucose data from Dexcom Share API

The implementation is divided in the following classes and modules:

#### BloodGlucose
The class that represents a blood glucose measurement. It has 3 fields:
- **value**: The blood glucose value in mg/dl
- **timestamp** The moment in which the blood glucose was measured
- **trend**: The change rate considering previous measurements. It is represented as an integer

Additionally, we also expose a few helpful properties:
- **mg_dl**: alias to **value**
- **mmol**: The blood glucose value in mmol
- **trend_symbol** and **trend_description**: human-friendly representations of the trend's meaning

#### BloodGlucoseUtils::ApiHandler
Encapsulates the logic to interact with Dexcom Share API. Takes care of preparing the request and processing the response

#### BloodGlucoseUtils::ClassMethods
Class methods for the `BloodGlucose` class, mostly to expose the interactions with the API. There are two currently: `get_last` and `last`