### PR TITLE
Including Session ID in the Blood Glucose requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    dexcom (0.2.0)
+    dexcom (0.2.1)
       httparty
 
 GEM

--- a/lib/dexcom/blood_glucose/api_handler.rb
+++ b/lib/dexcom/blood_glucose/api_handler.rb
@@ -42,7 +42,8 @@ module Dexcom
       def query(max_count)
         {
           maxCount: max_count,
-          minutes: MAX_MINUTES
+          minutes: MAX_MINUTES,
+          sessionId: Dexcom::Authentication.session_id
         }
       end
 
@@ -50,7 +51,6 @@ module Dexcom
         timestamp_info = blood_glucose_response_item['WT']
         timestamp_regex = /(\d+)000/
         timestamp = timestamp_info[timestamp_regex, 1]
-        utc = '+00:00'
 
         DateTime.strptime(timestamp, '%s')
       end

--- a/lib/dexcom/version.rb
+++ b/lib/dexcom/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dexcom
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/dexcom/blood_glucose_spec.rb
+++ b/spec/dexcom/blood_glucose_spec.rb
@@ -14,11 +14,13 @@ RSpec.shared_examples 'retrieves blood glucose values' do |number_of_values|
   let(:response_body) { (blood_glucose_response_item * number_of_values).to_json }
 
   before do
+    allow(Dexcom::Authentication).to receive(:session_id).and_return '1234-56-7890'
+
     @blood_glucose_request =
       stub_request(:post, "#{base_url}/Publisher/ReadPublisherLatestGlucoseValues")
       .with(
         headers: { 'User-Agent' => 'Dexcom Share/3.0.2.11 CFNetwork/711.2.23 Darwin/14.0.0' },
-        query: { minutes: 1440, maxCount: number_of_values }
+        query: { minutes: 1440, maxCount: number_of_values, sessionId: '1234-56-7890' }
       )
       .to_return(status: 200, body: response_body)
   end


### PR DESCRIPTION
## Description
The Session ID is the value that Dexcom Share uses to identify the user
whose information is being requested. We need to include it in order to
retrieve valid data

On #1 we forgot to include it, and therefore the gem wasn't making valid requests. This commit fixes it.