### PR TITLE
Filter BG readings older than the specified minutes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     rspec-support (3.9.3)
     safe_yaml (1.0.5)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     webmock (3.8.3)
@@ -70,6 +71,7 @@ DEPENDENCIES
   factory_bot
   pry
   rspec
+  timecop
   webmock
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    dexcom (0.2.2)
+    dexcom (0.3.0)
+      activesupport
       httparty
 
 GEM

--- a/dexcom.gemspec
+++ b/dexcom.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables    = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths  = ['lib']
 
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'httparty'
 
   spec.add_development_dependency 'bundler'

--- a/dexcom.gemspec
+++ b/dexcom.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'webmock'
 end

--- a/lib/dexcom/blood_glucose/class_methods.rb
+++ b/lib/dexcom/blood_glucose/class_methods.rb
@@ -14,7 +14,13 @@ module Dexcom
         number_of_values = calculate_number_of_values(max_count, minutes)
 
         response = make_api_request(number_of_values)
-        process_api_response(response)
+        blood_glucose_values = process_api_response(response)
+
+        unless minutes.nil?
+          remove_older_than_minutes!(blood_glucose_values, minutes)
+        end
+
+        blood_glucose_values
       end
 
       private
@@ -27,6 +33,13 @@ module Dexcom
         else
           [max_count, minutes / MINUTES_PER_DATAPOINT].min
         end
+      end
+
+      def remove_older_than_minutes!(blood_glucose_values, minutes)
+        latest_timestamp_allowed = DateTime.now - Helpers.minutes_to_datetime_delta(minutes)
+
+        blood_glucose_values
+        .select! { |bg| bg.timestamp >= latest_timestamp_allowed }
       end
     end
   end

--- a/lib/dexcom/version.rb
+++ b/lib/dexcom/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dexcom
-  VERSION = '0.2.2'
+  VERSION = '0.3.0'
 end

--- a/spec/dexcom/blood_glucose_spec.rb
+++ b/spec/dexcom/blood_glucose_spec.rb
@@ -24,7 +24,6 @@ RSpec.shared_examples 'retrieves blood glucose values' do |number_of_values|
 end
 
 RSpec.describe Dexcom::BloodGlucose do
-
   describe 'fields and properties' do
     subject(:bg) { build(:blood_glucose) }
 
@@ -58,6 +57,14 @@ RSpec.describe Dexcom::BloodGlucose do
           query: { minutes: 1440, maxCount: number_of_values, sessionId: '1234-56-7890' }
         )
         .to_return(status: 200, body: response_body)
+    end
+
+    around do |example|
+      Timecop.freeze DateTime.new(2020, 6, 10, 21, 43, 14, '+00:00')
+
+      example.run
+
+      Timecop.return
     end
 
     describe '.get_last' do

--- a/spec/dexcom/blood_glucose_spec.rb
+++ b/spec/dexcom/blood_glucose_spec.rb
@@ -15,7 +15,7 @@ RSpec.shared_examples 'retrieves blood glucose values' do |number_of_values|
 
   it 'correctly parses the BloodGlucose data' do
     result = subject
-    bg = result.first
+    bg = result.last
 
     expect(bg.value).to eq 96
     expect(bg.trend).to eq 4
@@ -35,17 +35,9 @@ RSpec.describe Dexcom::BloodGlucose do
   end
 
   describe 'API methods' do
+    let(:current_time) { DateTime.new(2020, 6, 10, 21, 43, 14, '+00:00') }
     let(:base_url) { 'https://shareous1.dexcom.com/ShareWebServices/Services' }
-    let(:blood_glucose_response_item) do
-      [{
-        'DT': '/Date(1591832594000+0000)/',
-        'ST': '/Date(1591825394000)/',
-        'Trend': 4,
-        'Value': 96,
-        'WT': '/Date(1591825394000)/'
-      }]
-    end
-    let(:response_body) { (blood_glucose_response_item * number_of_values).to_json }
+    let(:response_body) { Helpers.mock_api_bgs(current_time, number_of_values).to_json }
 
     before do
       allow(Dexcom::Authentication).to receive(:session_id).and_return '1234-56-7890'

--- a/spec/dexcom/blood_glucose_spec.rb
+++ b/spec/dexcom/blood_glucose_spec.rb
@@ -24,6 +24,8 @@ RSpec.shared_examples 'retrieves blood glucose values' do |number_of_values|
 end
 
 RSpec.describe Dexcom::BloodGlucose do
+  MINUTES_BETWEEN_BGS = 5
+
   describe 'fields and properties' do
     subject(:bg) { build(:blood_glucose) }
 
@@ -77,19 +79,16 @@ RSpec.describe Dexcom::BloodGlucose do
 
       context 'when is called with minutes' do
         let(:number_of_values) { 3 }
-        minutes = 15
-        subject { Dexcom::BloodGlucose.get_last(minutes: minutes) }
+        subject { Dexcom::BloodGlucose.get_last(minutes: 15) }
 
-        it_behaves_like 'retrieves blood glucose values', (minutes / 5)
+        it_behaves_like 'retrieves blood glucose values', (15 / MINUTES_BETWEEN_BGS)
       end
 
       context 'when is called with a max_count and minutes' do
         let(:number_of_values) { 4 }
-        minutes = 20
-        max_count = 6
-        subject { Dexcom::BloodGlucose.get_last(minutes: minutes, max_count: max_count) }
+        subject { Dexcom::BloodGlucose.get_last(minutes: 20, max_count: 6) }
 
-        it_behaves_like 'retrieves blood glucose values', [minutes / 5, max_count].min
+        it_behaves_like 'retrieves blood glucose values', [20 / MINUTES_BETWEEN_BGS, 6].min
       end
     end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,2 +1,18 @@
 module Helpers
+  def self.mock_api_bgs(last_datetime, number_of_values=1)
+    mock_api_bg(last_datetime) * number_of_values
+  end
+
+  def self.mock_api_bg(datetime)
+    unix_timestamp = datetime.to_time.to_i
+    unix_timestamp_in_millis = unix_timestamp * 1000
+
+    [{
+      'DT': "/Date(#{unix_timestamp_in_millis}+0000)/",
+      'ST': "/Date(#{unix_timestamp_in_millis})/",
+      'Trend': 4,
+      'Value': 96,
+      'WT': "/Date(#{unix_timestamp_in_millis})/"
+    }]
+  end
 end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,18 +1,29 @@
 module Helpers
+  MILLIS_PER_SECOND = 1000
+  MINUTES_BETWEEN_BGS = 5
+  MINUTES_IN_A_DAY = 24*60
+
   def self.mock_api_bgs(last_datetime, number_of_values=1)
-    mock_api_bg(last_datetime) * number_of_values
+    (number_of_values - 1).downto(0)
+      .map { |index| index * MINUTES_BETWEEN_BGS }
+      .map { |delay_in_minutes| minutes_to_datetime_delta(delay_in_minutes) }
+      .map { |datetime_delta| mock_api_bg(last_datetime - datetime_delta) }
   end
 
   def self.mock_api_bg(datetime)
     unix_timestamp = datetime.to_time.to_i
     unix_timestamp_in_millis = unix_timestamp * 1000
 
-    [{
+    {
       'DT': "/Date(#{unix_timestamp_in_millis}+0000)/",
       'ST': "/Date(#{unix_timestamp_in_millis})/",
       'Trend': 4,
       'Value': 96,
       'WT': "/Date(#{unix_timestamp_in_millis})/"
-    }]
+    }
+  end
+
+  def self.minutes_to_datetime_delta(minutes)
+    minutes.to_f / MINUTES_IN_A_DAY
   end
 end


### PR DESCRIPTION
## Description
The `Dexcom::BloodGlucose.get_last` method accepts a `minutes` argument, to specify that we want to get the BG readings published since those minutes ago. Currently, we are only using it to calculate how many datapoints we had to ask, knowing that Dexcom publishes a reading every 5 minutes. For example, if we call `Dexcom::BloodGlucose.get_last(minutes: 20)`, the code will get the last 4 published readings.

However, if the data  in Dexcom is outdated (e.g. because the transmitter lost connection and couldn't send the latest data), those 4 readings could be more than 20 minutes old. This is counterintuitive, because to get a fixed set of datapoints we already have the `max_count` argument.

This PR adds logic to filter out readings according to the timestamp whenever the minutes argument is used.

Additionally, we bump the Gem version to `0.3.0` to prepare a new release with this change. 