### PR TITLE
Adding configuration options for logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,6 @@ common: &common
 
 
 jobs:
-    "ruby-25":
-        <<: *common
-        docker:
-            - image: circleci/ruby:2.5
     "ruby-26":
         <<: *common
         docker:
@@ -41,10 +37,14 @@ jobs:
         <<: *common
         docker:
             - image: ruby:2.7
+    "ruby-30":
+        <<: *common
+        docker:
+            - image: ruby:3.0
 workflows:
     version: 2.1
     build:
         jobs:
-            - "ruby-25"
             - "ruby-26"
             - "ruby-27"
+            - "ruby-30"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,66 +1,67 @@
 PATH
   remote: .
   specs:
-    dexcom (0.3.0)
+    dexcom (0.3.1)
       activesupport
       httparty
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    activesupport (5.2.3)
+    activesupport (6.1.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    climate_control (0.2.0)
+    climate_control (1.0.1)
     coderay (1.1.3)
-    concurrent-ruby (1.1.5)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
-    diff-lcs (1.3)
-    factory_bot (5.0.2)
-      activesupport (>= 4.2.0)
+    concurrent-ruby (1.1.9)
+    crack (0.4.5)
+      rexml
+    diff-lcs (1.4.4)
+    factory_bot (6.2.0)
+      activesupport (>= 5.0.0)
     hashdiff (1.0.1)
-    httparty (0.18.0)
+    httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.6.0)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.0512)
-    minitest (5.11.3)
+    mime-types-data (3.2021.0704)
+    minitest (5.14.4)
     multi_xml (0.6.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
-    safe_yaml (1.0.5)
-    thread_safe (0.3.6)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
     timecop (0.9.1)
-    tzinfo (1.2.5)
-      thread_safe (~> 0.1)
-    webmock (3.8.3)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    webmock (3.13.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby
@@ -76,4 +77,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.0.2
+   2.2.21

--- a/lib/dexcom.rb
+++ b/lib/dexcom.rb
@@ -6,14 +6,4 @@ require 'dexcom/configuration'
 require 'dexcom/constants'
 require 'dexcom/version'
 
-module Dexcom
-  class << self
-    def configuration
-      @configuration ||= Configuration.new
-    end
-
-    def configure
-      yield configuration
-    end
-  end
-end
+module Dexcom; end

--- a/lib/dexcom/authentication.rb
+++ b/lib/dexcom/authentication.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-require 'httparty'
+require 'utils/httparty_configured'
 
 module Dexcom
   class Authentication
+    include ::Utils::HTTPartyConfigured
+
     class << self
       def access_token
         refresh_access_token if @access_token.nil?

--- a/lib/dexcom/blood_glucose/api_handler.rb
+++ b/lib/dexcom/blood_glucose/api_handler.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require 'utils/httparty_configured'
+
 module Dexcom
   module BloodGlucoseUtils
     module ApiHandler
+      include ::Utils::HTTPartyConfigured
+
       MAX_MINUTES = 1440
 
       def make_api_request(number_of_values)

--- a/lib/dexcom/configuration.rb
+++ b/lib/dexcom/configuration.rb
@@ -2,16 +2,37 @@
 
 module Dexcom
   class Configuration
-    attr_accessor :username, :password, :outside_usa
+    attr_accessor :username, :password, :outside_usa, :logger, :log_level
+
+    DEFAULT_LOGGER = nil
+    DEFAULT_LOGGER_LEVEL = :info
 
     def initialize
       @username = nil
       @password = nil
       @outside_usa = nil
+      @logger = DEFAULT_LOGGER
+      @log_level = DEFAULT_LOGGER_LEVEL
     end
 
     def base_url
       outside_usa ? URL_BASE_OUTSIDE_USA : URL_BASE
+    end
+  end
+
+  class << self
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    def configuration=(config)
+      raise StandardError('Invalid configuration provided') unless config.is_a? Dexcom::Configuration
+
+      @configuration = config
+    end
+
+    def configure
+      yield configuration
     end
   end
 end

--- a/lib/dexcom/version.rb
+++ b/lib/dexcom/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Dexcom
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/lib/utils/httparty_configured.rb
+++ b/lib/utils/httparty_configured.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'httparty'
+
+require 'dexcom/configuration'
+
+module Utils
+  module HTTPartyConfigured
+    include HTTParty
+
+    config = Dexcom.configuration
+
+    unless config.logger.nil?
+      logger config.logger, config.log_level, :apache
+      debug_output config.logger if config.log_level == :debug
+    end
+  end
+end

--- a/spec/dexcom/configuration_spec.rb
+++ b/spec/dexcom/configuration_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe Dexcom::Configuration do
+  let(:config) { Dexcom.configuration }
+
+  # We don't want to share configuration between specs
+  before { Dexcom.configuration = Dexcom::Configuration.new }
+
+  it 'adds the Dexcom.configure method' do
+    expect(Dexcom).to respond_to(:configure)
+  end
+
+  it 'adds the Dexcom.configuration method' do
+    expect(Dexcom).to respond_to(:configuration)
+  end
+
+  describe 'Dexcom.configuration' do
+    it 'allows to provide a configuration directly' do
+      new_config = Dexcom::Configuration.new
+      new_config.username = 'new_username'
+
+      Dexcom.configuration = new_config
+
+      expect(Dexcom.configuration.username).to eq 'new_username'
+    end
+
+    it 'raises an error if the configuration is invalid' do
+      expect { Dexcom.configuration = nil }.to raise_error StandardError
+    end
+  end
+
+  describe 'Dexcom.configure' do
+    it 'sets username' do
+      Dexcom.configure do |c|
+        c.username = 'username'
+      end
+
+      expect(config.username).to eq 'username'
+    end
+
+    it 'sets password' do
+      Dexcom.configure do |c|
+        c.password = 'password'
+      end
+
+      expect(config.password).to eq 'password'
+    end
+
+    it 'sets outside_usa' do
+      Dexcom.configure do |c|
+        c.outside_usa = false
+      end
+
+      expect(config.outside_usa).to eq false
+    end
+
+    it 'sets logger' do
+      logger = OpenStruct.new
+
+      Dexcom.configure do |c|
+        c.logger = logger
+      end
+
+      expect(config.logger).to eq logger
+    end
+
+    it 'sets log_level' do
+      Dexcom.configure do |c|
+        c.log_level = :debug
+      end
+
+      expect(config.log_level).to eq :debug
+    end
+  end
+
+  context 'default values' do
+    it 'logger is nil' do
+      expect(config.logger).to be_nil
+    end
+
+    it 'log_level is :info' do
+      expect(config.log_level).to eq :info
+    end
+  end
+end

--- a/spec/dexcom_spec.rb
+++ b/spec/dexcom_spec.rb
@@ -4,23 +4,4 @@ RSpec.describe Dexcom do
   it 'has a version number' do
     expect(Dexcom::VERSION).not_to be_nil
   end
-
-  describe '.configure' do
-    it 'sets the class configuration' do
-      username = 'username'
-      password = 'password'
-      outside_usa = true
-
-      described_class.configure do |config|
-        config.username = username
-        config.password = password
-        config.outside_usa = outside_usa
-      end
-
-      configuration = described_class.configuration
-      expect(configuration.username).to eq username
-      expect(configuration.password).to eq password
-      expect(configuration.outside_usa).to eq outside_usa
-    end
-  end
 end


### PR DESCRIPTION
## Description
Adding additional configuration options to allow specifying a logger and
logger level that the gem will use. This will be useful to have better
visibility of the operations the gem is doing.

Currently, we will add logging only to the HTTP requests, by using
HTTParty logging options

## Extras
As part of this PR, we have added some other minor improvements:
- Start building for Ruby 3.0. (new supported version) and stop building for Ruby 2.5 (out of support)
- Explicitly specify Rubygems HTTPS endpoint, to prevent using the HTTP version
